### PR TITLE
add cublasSnrm2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ openacc_c_main
 cuda_map
 openacc_streams
 openacc_cuda_device
+acc_malloc
+openacc_c_cublas_v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-EXES=cuda_main openacc_c_main openacc_c_cublas thrust cuda_map acc_malloc openacc_streams openacc_cuda_device
+EXES=cuda_main openacc_c_main openacc_c_cublas openacc_c_cublas_v2 thrust cuda_map acc_malloc openacc_streams openacc_cuda_device
 
 ifeq "$(PE_ENV)" "CRAY"
 # Cray Compiler
@@ -14,13 +14,13 @@ LDFLAGS=-L$(CUDA_HOME)/lib64 -lcudart
 else
 # PGI Compiler
 EXES+=cuf_main cuf_openacc_main openacc_cublas  
-CXX=pgc++
+CXX=nvc++
 CXXFLAGS=-fast -acc -ta=nvidia:rdc -Minfo=accel
-CC=pgcc
+CC=nvc
 CFLAGS=-fast -acc -ta=nvidia:rdc -Minfo=accel
 CUDAC=nvcc
 CUDAFLAGS=
-FC=pgfortran
+FC=nvfortran
 FFLAGS=-fast -acc -ta=nvidia -Minfo=accel
 LDFLAGS=-Mcuda #-L$(CUDA_HOME)/lib64 -lcudart
 endif
@@ -28,10 +28,13 @@ endif
 all: $(EXES)
 
 openacc_cublas: openacc_cublas.o
-	$(FC) -o $@ $(CFLAGS) $^ $(LDFLAGS) -lcublas -Mcuda
+	$(FC) -o $@ $(CFLAGS) $^ $(LDFLAGS) -Mcudalib=cublas
 
 openacc_c_cublas: openacc_c_cublas.o
-	$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS) -lcublas
+	$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS) -Mcudalib=cublas
+
+openacc_c_cublas_v2: openacc_c_cublas_v2.o
+	$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS) -Mcudalib=cublas
 
 openacc_c_main: saxpy_cuda.o openacc_c_main.o
 	$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CXXFLAGS=-hlist=a
 CC=cc
 CFLAGS=-hlist=a
 CUDAC=nvcc
-CUDAFLAGS=
+CUDAFLAGS=-gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80
 FC=ftn
 FFLAGS=-ra
 LDFLAGS=-L$(CUDA_HOME)/lib64 -lcudart
@@ -15,14 +15,16 @@ else
 # PGI Compiler
 EXES+=cuf_main cuf_openacc_main openacc_cublas  
 CXX=nvc++
-CXXFLAGS=-fast -acc -ta=nvidia:rdc -Minfo=accel
+CXXFLAGS=-fast -acc -Minfo=accel -gpu=cc60,cc70,cc75,cc80
 CC=nvc
-CFLAGS=-fast -acc -ta=nvidia:rdc -Minfo=accel
+CFLAGS=-fast -acc -Minfo=accel -gpu=cc60,cc70,cc75,cc80
 CUDAC=nvcc
-CUDAFLAGS=
+# Hard-coded architectures to avoid build issue when arches are added or
+# removed from compilers
+CUDAFLAGS=-gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80
 FC=nvfortran
-FFLAGS=-fast -acc -ta=nvidia -Minfo=accel
-LDFLAGS=-Mcuda #-L$(CUDA_HOME)/lib64 -lcudart
+FFLAGS=-fast -acc -Minfo=accel -gpu=cc60,cc70,cc75,cc80
+LDFLAGS=-Mcuda 
 endif
 
 all: $(EXES)
@@ -37,7 +39,7 @@ openacc_c_cublas_v2: openacc_c_cublas_v2.o
 	$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS) -Mcudalib=cublas
 
 openacc_c_main: saxpy_cuda.o openacc_c_main.o
-	$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
+	$(CXX) -o $@ $(CFLAGS) $^ $(LDFLAGS)
 
 cuda_main: saxpy_openacc_c.o cuda_main.o
 	$(CXX) -o $@ $(CFLAGS) $^ $(LDFLAGS)
@@ -64,7 +66,7 @@ saxpy_cuda_device.o: saxpy_cuda_device.cu
 	$(CUDAC) $(CUDAFLAGS) -rdc true -c $<
 	
 openacc_streams: saxpy_cuda_async.o openacc_streams.o
-	$(CC) -o $@ $(CXXFLAGS) $^ $(LDFLAGS)
+	$(CXX) -o $@ $(CXXFLAGS) $^ $(LDFLAGS)
 
 .SUFFIXES:
 .SUFFIXES: .c .o .f90 .cu .cpp .cuf

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Author: Jeff Larkin <jlarkin@nvidia.com>
 
 This repository demonstrates interoperability between OpenACC and various other
 GPU programming models. An OpenACC-enabled compiler is required. The default
-makefile has been written for PGI and tested with PGI 14.7, although most if
+makefile has been written for PGI and tested with PGI 20.9, although most if
 not all examples will work with earlier versions.
 
 If building with the Cray Compiler Environment the makefile will detect this

--- a/openacc_c_cublas_v2.c
+++ b/openacc_c_cublas_v2.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "cublas_v2.h"
+
+int main(int argc, char **argv)
+{
+  float *x, *y, tmp;
+  int n = 2000, i;
+  cublasStatus_t stat = CUBLAS_STATUS_SUCCESS;
+
+  x = (float*)malloc(n*sizeof(float));
+  y = (float*)malloc(n*sizeof(float));
+
+  #pragma acc enter data create(x[0:n]) create(y[0:n])
+      
+      cublasHandle_t handle;
+      stat = cublasCreate(&handle);
+      if ( CUBLAS_STATUS_SUCCESS != stat ) {
+        printf("CUBLAS initialization failed\n");
+      }
+
+    #pragma acc kernels
+    {
+      for( i = 0; i < n; i++)
+      {
+        x[i] = 1.0f;
+        y[i] = 0.0f;
+      }
+    }
+
+    #pragma acc host_data use_device(x,y)
+    {
+        const float alpha = 2.0f;
+        stat = cublasSaxpy(handle, n, &alpha, x, 1, y, 1);
+        if (stat != CUBLAS_STATUS_SUCCESS) {
+            printf("cublasSaxpy failed\n");
+        } 
+        stat = cublasSnrm2(handle, n, x, 1, &tmp); 
+        if (stat != CUBLAS_STATUS_SUCCESS) {
+            printf("cublasSnrm2 failed\n");
+        }
+    }
+    
+    cublasDestroy(handle);
+  
+#pragma acc exit data copyout(x[0:n]) copyout(y[0:n]) 
+
+  fprintf(stdout, "y[0] = %f\n",y[0]);
+  fprintf(stdout, "x[0] = %f\n",x[0]);
+  fprintf(stdout, "norm2(x) = %f\n",tmp);
+  return 0;
+}
+

--- a/openacc_cublas.f90
+++ b/openacc_cublas.f90
@@ -1,7 +1,14 @@
 program main
   use cublas
+  implicit none
   integer, parameter :: N = 2**20
   real, dimension(N) :: X, Y
+  real:: nrm2
+  type(cublasHandle) :: h
+  integer :: istat
+  
+  istat = cublasCreate(h)
+  if (istat .ne. CUBLAS_STATUS_SUCCESS) print *,istat
 
   !$acc data create(x,y)
   !$acc kernels
@@ -11,9 +18,16 @@ program main
 
   !$acc host_data use_device(x,y)
   call cublassaxpy(N, 2.0, x, 1, y, 1)
+  istat = cublasSnrm2_v2(h, N, x, 1, nrm2)
+  if (istat .ne. CUBLAS_STATUS_SUCCESS) print *,istat
   !$acc end host_data
+  
   !$acc update self(y)
   !$acc end data
 
+  istat = cublasDestroy(h)
   print *, y(1)
+  print*,nrm2
 end program
+
+


### PR DESCRIPTION
1) In openacc_cublas.f90, add a new cublasSnrm2 call to use cublas_v2 module functions from an openACC program
2) create a new openacc_c_cublas_v2.c to call cublas functions with cublas handles from an openACC program